### PR TITLE
:bug: fix: 소셜 로그인 구현

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,4 +1,5 @@
 from dj_rest_auth.serializers import LoginSerializer
+from dj_rest_auth.registration.serializers import SocialLoginSerializer
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
 from .models import CustomUser
@@ -49,3 +50,67 @@ class CustomLoginSerializer(LoginSerializer):
             return attrs
 
         raise serializers.ValidationError("Invalid email or password.")
+
+
+class CustomSocialLoginSerializer(SocialLoginSerializer):
+    """소셜 로그인 과정에서 필요한 토큰 검증과 사용자 처리를 담당하는 시리얼라이저.
+
+    SocialLoginSerializer를 상속받아 Google OAuth 토큰 검증 중 발생할 수 있는
+    TypeError를 처리합니다. 이는 dj-rest-auth의 기본 serializer가 access_token만으로는
+    처리하지 못하는 Google OAuth의 특수한 토큰 형식을 지원하기 위함입니다.
+
+    일반적인 OAuth 처리 과정:
+    1. 프론트엔드로부터 받은 access_token 확인
+    2. Google OAuth adapter를 통해 토큰 검증
+    3. 검증된 토큰으로 소셜 로그인 진행
+    4. 필요한 경우 새 사용자 생성
+    """
+
+    def validate(self, attrs):
+        """소셜 로그인 토큰을 검증하고 사용자 객체를 반환합니다.
+
+        Args:
+            attrs (dict): 검증할 데이터. access_token을 포함해야 함
+
+        Returns:
+            dict: 검증된 데이터와 사용자 객체
+
+        Raises:
+            ValidationError: view나 adapter_class가 없거나 access_token이 없는 경우
+        """
+        try:
+            return super().validate(attrs)
+        except TypeError:
+            view = self.context.get("view")
+            request = self._get_request()
+
+            if not view:
+                raise serializers.ValidationError(
+                    "View is not defined, pass it as a context variable"
+                )
+
+            adapter_class = getattr(view, "adapter_class", None)
+            if not adapter_class:
+                raise serializers.ValidationError("Define adapter_class in view")
+
+            adapter = adapter_class(request)
+            app = adapter.get_provider().app
+
+            access_token = attrs.get("access_token")
+            if not access_token:
+                raise serializers.ValidationError(
+                    "Incorrect input. access_token is required."
+                )
+
+            social_token = adapter.parse_token({"access_token": access_token})
+            social_token.app = app
+
+            login = self.get_social_login(adapter, app, social_token, access_token)
+            ret = self.complete_social_login(request, login)
+
+            if not login.is_existing:
+                login.lookup()
+                login.save(request, connect=True)
+
+            attrs["user"] = login.account.user
+            return attrs

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,14 +1,16 @@
-from django.urls import path, re_path
+from django.urls import path, re_path, include
 from dj_rest_auth.views import (
     PasswordResetView,
     PasswordResetConfirmView,
     PasswordChangeView,
-    LogoutView,
 )
-from dj_rest_auth.registration.views import RegisterView
 from . import views
 
 urlpatterns = [
+    # 기본 인증 및 등록 URLs
+    path("", include("dj_rest_auth.urls")),
+    path("registration/", include("dj_rest_auth.registration.urls")),
+    # 비밀번호 관리
     path("password/reset/", PasswordResetView.as_view(), name="rest_password_reset"),
     re_path(
         r"^password/reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,40})/$",
@@ -16,9 +18,8 @@ urlpatterns = [
         name="password_reset_confirm",
     ),
     path("password/change/", PasswordChangeView.as_view(), name="rest_password_change"),
-    path("login/", views.CustomLoginView.as_view(), name="rest_login"),
-    path("logout/", LogoutView.as_view(), name="rest_logout"),
-    path("registration/", RegisterView.as_view(), name="rest_register"),
+    # 소셜 로그인
     path("google/", views.GoogleLogin.as_view(), name="google_login"),
+    # 사용자 정보
     path("current-user/", views.CurrentUserView.as_view(), name="current_user"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -5,27 +5,81 @@ from dj_rest_auth.views import LoginView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated
-from .serializers import CustomLoginSerializer
+from .serializers import CustomLoginSerializer, CustomSocialLoginSerializer
 from profiles.serializers import ProfileSerializer
+from django.conf import settings
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework import status
 
 
 class GoogleLogin(SocialLoginView):
-    """
-    Google OAuth2를 통한 소셜 로그인을 처리하는 뷰.
+    """Google OAuth2를 이용한 소셜 로그인을 처리하는 뷰.
 
-    이 클래스는 Google OAuth2 어댑터를 사용하여 사용자 인증을 처리합니다.
+    SocialLoginView를 상속받아 Google OAuth2 인증을 처리하고 JWT 토큰을 발급합니다.
 
     Attributes:
-        adapter_class (GoogleOAuth2Adapter): Google OAuth2 인증을 위한 어댑터 클래스.
-        callback_url (str): 인증 후 리다이렉트될 URL.
-        client_class (OAuth2Client): OAuth2 클라이언트 클래스.
+        client_class: OAuth2 클라이언트 클래스
+        adapter_class: Google OAuth2 어댑터 클래스
+        callback_url: Google OAuth 콜백 URL
+        serializer_class: 소셜 로그인 시리얼라이저
     """
 
-    adapter_class = GoogleOAuth2Adapter
-    callback_url = (
-        "http://localhost:8000/accounts/google/callback/"  # 프론트엔드 URL로 변경 필요
-    )
     client_class = OAuth2Client
+    adapter_class = GoogleOAuth2Adapter
+    callback_url = settings.GOOGLE_CALLBACK_URI
+    serializer_class = CustomSocialLoginSerializer
+
+    def get_response(self):
+        """JWT 토큰이 포함된 응답을 반환합니다.
+
+        Returns:
+            Response: JWT access/refresh 토큰과 사용자 정보가 포함된 응답
+        """
+        response = super().get_response()
+
+        # JWT 토큰 생성
+        if self.user:
+            refresh = RefreshToken.for_user(self.user)
+            response.data = {
+                "access": str(refresh.access_token),
+                "refresh": str(refresh),
+                "user": {
+                    "id": str(self.user.id),
+                    "email": self.user.email,
+                    "username": self.user.username,
+                },
+            }
+
+        return response
+
+    def post(self, request, *args, **kwargs):
+        """Google access token으로 인증을 처리하고 결과를 반환합니다.
+
+        Args:
+            request: HTTP 요청 객체
+
+        Returns:
+            Response: 인증 결과 또는 에러 응답
+        """
+        try:
+            response = super().post(request, *args, **kwargs)
+            print("Response data from post:", response.data)
+            return response
+
+        except Exception as e:
+            print("Error in GoogleLogin:", str(e))
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+    def get_error_response(self, error):
+        """에러 응답을 생성합니다.
+
+        Args:
+            error: 발생한 에러 객체
+
+        Returns:
+            Response: 에러 메시지와 400 상태 코드를 포함한 응답
+        """
+        return Response({"error": str(error)}, status=status.HTTP_400_BAD_REQUEST)
 
 
 class CustomLoginView(LoginView):

--- a/config/settings.py
+++ b/config/settings.py
@@ -147,8 +147,26 @@ AUTHENTICATION_BACKENDS = [
     "allauth.account.auth_backends.AuthenticationBackend",
 ]
 
+# user custom models
+AUTH_USER_MODEL = "accounts.CustomUser"
+
 # 소셜 로그인용
 SITE_ID = 1
+
+# allauth settings
+ACCOUNT_AUTHENTICATION_METHOD = "email"
+ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_USERNAME_REQUIRED = False
+ACCOUNT_USER_MODEL_USERNAME_FIELD = "username"
+
+REST_AUTH = {
+    "USE_JWT": True,
+    "JWT_AUTH_COOKIE": "my-app-auth",
+    "JWT_AUTH_REFRESH_COOKIE": "my-refresh-token",
+    "JWT_AUTH_HTTPONLY": False,
+    "JWT_AUTH_SAMESITE": "None",
+    "SESSION_LOGIN": False,
+}
 
 # 구글 소셜 계정 설정
 SOCIALACCOUNT_PROVIDERS = {
@@ -165,7 +183,9 @@ SOCIALACCOUNT_PROVIDERS = {
 
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
-GOOGLE_CALLBACK_URI = "http://3.36.50.126/accounts/google/login/callback/"
+GOOGLE_CALLBACK_URI = (
+    "http://127.0.0.1:5500/templates/google-callback.html"  # 프론트 callback url 지정
+)
 
 # SMTP(Simple Mail Transfer ProtocoL) 설정
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
@@ -202,6 +222,7 @@ CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:5500",
     "http://127.0.0.1:5500",
+    "https://accounts.google.com",
 ]
 
 # 추가 CORS 설정
@@ -232,25 +253,7 @@ CORS_EXPOSE_HEADERS = ["Content-Type", "X-CSRFToken"]
 # Crispy Forms 설정
 CRISPY_TEMPLATE_PACK = "bootstrap4"
 
-# user custom models
-AUTH_USER_MODEL = "accounts.CustomUser"
-
-# allauth settings
-ACCOUNT_AUTHENTICATION_METHOD = "email"
-ACCOUNT_EMAIL_REQUIRED = True
-ACCOUNT_USERNAME_REQUIRED = True
-ACCOUNT_USER_MODEL_USERNAME_FIELD = "username"
-
-REST_AUTH = {
-    "USE_JWT": True,
-    "JWT_AUTH_COOKIE": "my-app-auth",
-    "JWT_AUTH_REFRESH_COOKIE": "my-refresh-token",
-    "JWT_AUTH_HTTPONLY": False,
-    "JWT_AUTH_SAMESITE": "None",
-    "SESSION_LOGIN": False,
-}
-
-# jwt 설정
+# JWT 설정
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=60),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=1),


### PR DESCRIPTION
- dj-rest-auth의 기본 serializer가 access_token만으로는 처리하지 못하는 Google OAuth의 특수한 토큰 형식을 지원하기 위해 serializer 추가
- url 변경
- google OAuth2 인증 처리, jwt 토큰 발급 함수 추가
- 에러 응답 추가
- settings 위치 변경 및 google_callback_uri 프론트로 설정
- 프론트 코드도 수정했습니다