### PR TITLE
🐛 fix : Post 태그검색 기능 수정

### DIFF
--- a/search/filters.py
+++ b/search/filters.py
@@ -4,6 +4,7 @@ from django_filters import rest_framework as filters
 from chats.models import Message
 from posts.models import Post
 from market.models import Product
+from taggit.models import Tag
 
 User = get_user_model()
 
@@ -77,7 +78,8 @@ class PostFilter(filters.FilterSet):
 
         for word in words:
             if word.startswith("#"):
-                tag_query |= Q(tags__name__iexact=word[1:])
+                tag_name = word[1:]
+                tag_query |= Q(tags__name__contains=f'"{tag_name}"')
             else:
                 content_query |= (
                     Q(content__icontains=word)


### PR DESCRIPTION
태그가 DB에서 JSON 문자열로 저장되어있었습니다.
'["태그1","태그2","태그3"]' <- 이거 자체가 하나의 태그

이는 django-taggit이 의도한 방식이 아닙니다.
태그가 개별적으로 저장되어야 하는데, 전체 태그가 하나의 태그로 저장되어 있었습니다.

그래서 JSON 문자열 내에서 다시한번 검색하는 방식으로 현재 되어있습니다.
나중에 비슷한 코드를 사용할때는 모델설계부터 태그처리를 개별저장하는 방식으로 사용하는것이 좋다고 합니다.