### PR TITLE
:bug: fix: chats consumers.py, models,py, views.py 수정

### DIFF
--- a/chats/models.py
+++ b/chats/models.py
@@ -87,3 +87,10 @@ class WebSocketConnection(models.Model):
         for message in unread_messages:
             message.is_read = True
             message.save(update_fields=["is_read"])
+
+    @classmethod
+    def get_active_connections(cls, chat_room):
+        """
+        현재 활성 상태인 WebSocket 연결 목록을 반환
+        """
+        return cls.objects.filter(chat_room=chat_room, disconnected_at__isnull=True)


### PR DESCRIPTION
- 채널 레이어를 통해 받은 메세지 클라이언트에게 전송 메서드 추가
- 활성 상태인 웹소켓 연결 목록 반환 메서드 추가, model 마이그레이션 필요 없음
- 메세지 브로드캐스팅 추가
    - 클라이언트가 HTTP POST로 메시지를 생성하면, 데이터베이스에 저장
    - 동시에 WebSocket을 통해 해당 채팅방의 모든 참여자에게 즉시 메시지를 브로드캐스팅
    - 메시지는 데이터베이스에만 저장되고 실시간으로 전달되지 않음 문제 해결