### PR TITLE
🔀 merge: alarm에서 main으로 병합 요청(test>chats error fix)

### DIFF
--- a/chats/serializers.py
+++ b/chats/serializers.py
@@ -37,7 +37,7 @@ class ChatRoomSerializer(serializers.ModelSerializer):
         participants = validated_data.pop("participants")
 
         if len(participants) != 2:
-            raise serializers.ValidationError("1대1 채팅만 가능합니다.")
+            raise serializers.ValidationError({"error": "1대1 채팅만 가능합니다."})
 
         # 참가자 ID를 정렬한 후 room_key 생성
         participant_ids = sorted([str(participant.id) for participant in participants])
@@ -63,6 +63,11 @@ class ChatRoomSerializer(serializers.ModelSerializer):
         # 채팅방이 없는 경우 새로 생성
         chat_room = ChatRoom.objects.create(room_key=room_key)
         chat_room.participants.set(participants)
+
+        # 채팅방 이름 설정
+        participant_usernames = ", ".join([user.username for user in participants])
+        chat_room.name = f"{participant_usernames}의 대화"
+        chat_room.save()
 
         return chat_room
 


### PR DESCRIPTION
🐛 fix: chats 앱 에러 수정

- test_chatroom_creation 에러 : 채팅방 이름 설정 로직이 누락되어 추가
- test_invalid_participants 에러 : 테스트에서 기대하는 딕셔너리 형태로 응답 형식을 수정

그 외 69개의 모든 테스트 무결성 확인 완료